### PR TITLE
Better check for placeholder

### DIFF
--- a/tagger.js
+++ b/tagger.js
@@ -359,8 +359,10 @@
             $input.blur(function(e){
                 $container.css(styles_obj['.tagger-blurred']);
                 if($suggestions) $suggestions.hide();
-                if(placeholder && !self.getValues().length) placeholder.show();
-                else placeholder.hide();
+                if(placeholder){
+                    if(!self.getValues().length) placeholder.show();
+                    else placeholder.hide();
+                }
             });
             
             // Setup sortable plugin


### PR DESCRIPTION
Prevents throwing when no placeholder is defined
